### PR TITLE
Fixed joint winners issue

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -244,9 +244,10 @@ def rebuildStatistics(tournamentId):
 
 	db.session.commit()
 
-	#players = [player.entity.participants for player in Statistics.query.filter(Statistics.tournament_id == tournamentId).filter(Statistics.position == 1).all()]
-	players = [entity.participants.player for entity in Statistics.query.filter(Statistics.tournament_id == tournamentId).filter(Statistics.position == 1).all()]
+	players = [player.entity.participants for player in Statistics.query.filter(Statistics.tournament_id == tournamentId).filter(Statistics.position == 1).all()]
+
 	if players:
+		print(players)
 		winnerList = [player.player.name for player in players[0]]
 		winnerString = ", ".join(winnerList)
 		tournament = Tournament.query.filter(Tournament.id == tournamentId).first()

--- a/app/api.py
+++ b/app/api.py
@@ -74,7 +74,7 @@ def createTournamentType(description,gameWinsRequired):
 
 def getTournamentResults(id):
 
-	return Statistics.query.filter(Statistics.tournament_id == id).order_by(Statistics.match_wins.desc(), Statistics.game_win_percentage.desc()).all()
+	return Statistics.query.filter(Statistics.tournament_id == id).order_by(Statistics.match_wins.desc(), Statistics.game_win_percentage.desc(), Statistics.game_losses.asc()).all()
 
 def addPositions(statistics):
 

--- a/app/api.py
+++ b/app/api.py
@@ -244,8 +244,8 @@ def rebuildStatistics(tournamentId):
 
 	db.session.commit()
 
-	players = [player.entity.participants for player in Statistics.query.filter(Statistics.tournament_id == tournamentId).filter(Statistics.position == 1).all()]
-
+	#players = [player.entity.participants for player in Statistics.query.filter(Statistics.tournament_id == tournamentId).filter(Statistics.position == 1).all()]
+	players = [entity.participants.player for entity in Statistics.query.filter(Statistics.tournament_id == tournamentId).filter(Statistics.position == 1).all()]
 	if players:
 		winnerList = [player.player.name for player in players[0]]
 		winnerString = ", ".join(winnerList)

--- a/app/api.py
+++ b/app/api.py
@@ -247,8 +247,8 @@ def rebuildStatistics(tournamentId):
 	players = [player.entity.participants for player in Statistics.query.filter(Statistics.tournament_id == tournamentId).filter(Statistics.position == 1).all()]
 
 	if players:
-		print(players)
 		winnerList = [player.player.name for player in players[0]]
+		print(winnerList)
 		winnerString = ", ".join(winnerList)
 		tournament = Tournament.query.filter(Tournament.id == tournamentId).first()
 		tournament.winners = winnerString

--- a/app/api.py
+++ b/app/api.py
@@ -247,8 +247,9 @@ def rebuildStatistics(tournamentId):
 	players = [player.entity.participants for player in Statistics.query.filter(Statistics.tournament_id == tournamentId).filter(Statistics.position == 1).all()]
 
 	if players:
-		winnerList = [player.player.name for player in players[0]]
-		print(winnerList)
+		winnerList = []
+		for i in players:
+			winnerList += [player.player.name for player in i]
 		winnerString = ", ".join(winnerList)
 		tournament = Tournament.query.filter(Tournament.id == tournamentId).first()
 		tournament.winners = winnerString

--- a/app/rebuildStats.py
+++ b/app/rebuildStats.py
@@ -4,3 +4,4 @@ from app.models import Tournament
 for tournament in getTournaments():
 	rebuildStatistics(tournament.id)
 	print(tournament.id)
+print("end")

--- a/app/rebuildStats.py
+++ b/app/rebuildStats.py
@@ -1,0 +1,5 @@
+from app.api import rebuildStatistics
+from app.models import Tournament
+
+for tournament in getTournaments():
+	rebuildStatistics(tournament.id)

--- a/app/rebuildStats.py
+++ b/app/rebuildStats.py
@@ -1,4 +1,4 @@
-from app.api import rebuildStatistics
+from app.api import *
 from app.models import Tournament
 
 for tournament in getTournaments():

--- a/app/rebuildStats.py
+++ b/app/rebuildStats.py
@@ -3,5 +3,3 @@ from app.models import Tournament
 
 for tournament in getTournaments():
 	rebuildStatistics(tournament.id)
-	print(tournament.id)
-print("end")

--- a/rebuildStats.py
+++ b/rebuildStats.py
@@ -3,4 +3,3 @@ from app.models import Tournament
 
 for tournament in getTournaments():
 	rebuildStatistics(tournament.id)
-	print(tournament.id)


### PR DESCRIPTION
The query was returning a list of players for each entity winning the tournament, and then the winnerlist was formed from players[0] - so only the players from the first entity were returned (hence why 2HG still showed two names).
