### PR TITLE
Increase Weighting For Older Drafts

### DIFF
--- a/app/pairings.py
+++ b/app/pairings.py
@@ -36,11 +36,9 @@ def getPairings(playerList):
 	matches = getMatches(playerList) 
 
 	tournamentWeightings = getTournamentWeightings(matches)
-	print(tournamentWeightings)
 
 	inputList = []
 	for match in matches:
-		print(tournamentWeightings[match[2]])
 		inputList.append((match[3], match[4], tournamentWeightings[match[2]]))
 
 	outputList = []

--- a/app/pairings.py
+++ b/app/pairings.py
@@ -35,9 +35,12 @@ def getPairings(playerList):
 
 	matches = getMatches(playerList) 
 
+	oldestTournament = getOldestTournament
+
 	inputList = []
 	for match in matches:
-		inputList.append((match[3], match[4], (match[2] * -1)))
+		matchWeighting = (match[2] - oldestTournament + 1) * (match[2] - oldestTournament + 1) * -1
+		inputList.append((match[3], match[4], matchWeighting))
 
 	outputList = []
 	outputList = enumerate(maxWeightMatching(inputList, True))
@@ -253,6 +256,13 @@ def flatten(l):
 		else:
 			yield el
 
+def getOldestTournament (matches):
+
+	tournaments = []
+	for match in matches:
+		tournaments.append(match[2])
+
+	return min(tournaments)
 
 
 

--- a/app/pairings.py
+++ b/app/pairings.py
@@ -35,11 +35,12 @@ def getPairings(playerList):
 
 	matches = getMatches(playerList) 
 
-	oldestTournament = getOldestTournament
+	oldestTournament = getOldestTournament(matches)
 
 	inputList = []
 	for match in matches:
-		matchWeighting = (match[2] - oldestTournament + 1) * (match[2] - oldestTournament + 1) * -1
+		match[2]
+		matchWeighting = -(match[2] - oldestTournament + 1) * (match[2] - oldestTournament + 1)
 		inputList.append((match[3], match[4], matchWeighting))
 
 	outputList = []

--- a/app/pairings.py
+++ b/app/pairings.py
@@ -35,13 +35,13 @@ def getPairings(playerList):
 
 	matches = getMatches(playerList) 
 
-	oldestTournament = getOldestTournament(matches)
+	tournamentWeightings = getTournamentWeightings(matches)
+	print(tournamentWeightings)
 
 	inputList = []
 	for match in matches:
-		match[2]
-		matchWeighting = -(match[2] - oldestTournament + 1) * (match[2] - oldestTournament + 1)
-		inputList.append((match[3], match[4], matchWeighting))
+		print(tournamentWeightings[match[2]])
+		inputList.append((match[3], match[4], tournamentWeightings[match[2]]))
 
 	outputList = []
 	outputList = enumerate(maxWeightMatching(inputList, True))
@@ -257,13 +257,15 @@ def flatten(l):
 		else:
 			yield el
 
-def getOldestTournament (matches):
+
+def getTournamentWeightings (matches):
 
 	tournaments = []
 	for match in matches:
-		tournaments.append(match[2])
+		if tournaments.count(match[2]) == 0:
+			tournaments.append(match[2])
 
-	return min(tournaments)
+	return {t[1]:t[0]*t[0] for t in enumerate(sorted(tournaments, reverse))}
 
 
 

--- a/app/pairings.py
+++ b/app/pairings.py
@@ -265,7 +265,7 @@ def getTournamentWeightings (matches):
 		if tournaments.count(match[2]) == 0:
 			tournaments.append(match[2])
 
-	return {t[1]:t[0]*t[0] for t in enumerate(sorted(tournaments, reverse))}
+	return {t[1]:t[0]*t[0] for t in enumerate(sorted(tournaments, reverse=True))}
 
 
 


### PR DESCRIPTION
Weighting is now based on enumerating the distinct tournaments from open matches in reverse order and multiplying the enumeration by itself.

For example, if we are running pairings and there are open matches in 5 tournaments for that selection of players, then the weightings will be as follows, from the earliest to the most recent tournament:
25, 16, 9, 4, 1