### PR TITLE
Slack api change

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -6,6 +6,7 @@ import smtplib
 import json
 from itertools import combinations
 from app.post import slack_bot
+import os
 
 from app import app, db
 
@@ -487,11 +488,11 @@ def slackResults(id):
 	with open('app/results.settings') as config:
 		settings = json.loads(config.read())
 
-	if app.config['TESTING'] == True:	
-		channel = settings['testing_channel_name']
-	else:	
-		channel = settings['channel_name']
-	results_bot = slack_bot(settings['channel_url'], channel, settings['bot_name'], settings['bot_icon'])
+	if app.config['TESTING'] == True:
+		channel = os.environ['TESTING_CHANNEL_ID']
+	else:
+		channel = os.environ['CHANNEL_ID']
+	results_bot = slack_bot(channel, settings['bot_name'], settings['bot_icon'])
 
 	tournament = getTournamentResults(id)
 

--- a/app/automatedPairings.py
+++ b/app/automatedPairings.py
@@ -35,7 +35,7 @@ def automatePairings():
 
 	token = str(os.environ['SLACK_TOKEN'])
 
-	pairingsChannel = Channel(token, settings['pairings_channel_name'])
+	pairingsChannel = Channel(token, os.environ['PAIRINGS_CHANNEL_ID'])
 	pairingsMessage = pairingsChannel.getPairingsMessage()
 
 	pairingsMessageReactions = []
@@ -74,10 +74,10 @@ def postDraftingMessage(playerList):
 		settings = json.loads(config.read())
 
 	if app.config['TESTING'] == True:
-		channel = settings['testing_channel_name']
+		channel = os.environ['TESTING_CHANNEL_ID']
 	else:
-		channel = settings['channel_name']
-	pairings_bot = slack_bot(settings['channel_url'], channel, settings['bot_name'], settings['bot_icon'])
+		channel = os.environ['CHANNEL_ID']
+	pairings_bot = slack_bot(channel, settings['bot_name'], settings['bot_icon'])
 
 	if playerList:
 

--- a/app/pairings.py
+++ b/app/pairings.py
@@ -9,6 +9,7 @@ import collections
 from app.post import slack_bot
 from app.mwmatching import maxWeightMatching
 import statistics
+import os
 
 from app import app, db
 
@@ -178,11 +179,11 @@ def slackPairings(normalPairings,twoHeadedPairings, remainder):
 	with open('app/pairings.settings') as config:
 		settings = json.loads(config.read())	
 
-	if app.config['TESTING'] == True:	
-		channel = settings['testing_channel_name']
-	else:	
-		channel = settings['channel_name']
-	pairings_bot = slack_bot(settings['channel_url'], channel, settings['bot_name'], settings['bot_icon'])
+	if app.config['TESTING'] == True:
+		channel = os.environ['TESTING_CHANNEL_ID']
+	else:
+		channel = os.environ['CHANNEL_ID']
+	pairings_bot = slack_bot(channel, settings['bot_name'], settings['bot_icon'])
 
 
 	if not normalPairings and not twoHeadedPairings:
@@ -209,7 +210,8 @@ def slackPairings(normalPairings,twoHeadedPairings, remainder):
 				attachment = {
 						'text': message,
         		    	'color': "#7CD197",
-        		    	'mrkdwn_in': ["text"]
+        		    	'mrkdwn_in': ["text"],
+        		    	'fallback': message 
      			  	 }
 
 				pairings_bot.post_attachment(attachment)
@@ -222,7 +224,8 @@ def slackPairings(normalPairings,twoHeadedPairings, remainder):
 				attachment = {
       					'text': message,
        				    'color': "#7CD197",
-       				    'mrkdwn_in': ["text"]
+       				    'mrkdwn_in': ["text"],
+        		    	'fallback': message 
       				 }
 
 				pairings_bot.post_attachment(attachment)
@@ -238,7 +241,8 @@ def slackPairings(normalPairings,twoHeadedPairings, remainder):
 			attachment = {
       					'text': message,
        				    'color': "#7CD197",
-       				    'mrkdwn_in': ["text"]
+       				    'mrkdwn_in': ["text"],
+        		    	'fallback': message 
       				 }
 
 			pairings_bot.post_attachment(attachment)	

--- a/app/pairings.settings
+++ b/app/pairings.settings
@@ -1,8 +1,4 @@
 	{
-		"channel_url":"https://hooks.slack.com/services/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",
-		"channel_name":"#fun-house",
-		"testing_channel_name":"#jhcmagic-testing",
-		"pairings_channel_name":"pairings",
 		"bot_name":"Spirit of Mike Burns",
 		"bot_icon":"https://cdn3.iconfinder.com/data/icons/mythical-creatures/300/20-512.png"
 	}

--- a/app/post.py
+++ b/app/post.py
@@ -1,3 +1,4 @@
+from app.slackApiChannel import Channel
 import requests
 import json
 import os
@@ -5,13 +6,14 @@ import datetime
 
 class slack_bot:
 
-	def __init__(self, hook_url, channel_name, bot_name, bot_icon, live=True):
-		self.hook_url = hook_url
+	def __init__(self, channel_id, bot_name, bot_icon, live=True):
+		self.token = os.environ['SLACK_TOKEN']
 		self.default_message = {
-		'channel': channel_name,
+		'token': self.token,
+		'channel': channel_id,
 		'username': bot_name,
 		'icon_url': bot_icon,
-		'link_names':'1'
+		'link_names':"1"
 		}
 		self.live = live
 		self.session = requests.session()
@@ -19,8 +21,7 @@ class slack_bot:
 	def post_message(self, message_text):
 		message = self.default_message.copy()
 		message['text'] = message_text
-		payload = {'payload':json.dumps(message)}
-		self._send_or_simulate(payload, 'simulating post of message: {!s}'.format(message_text))
+		self._send_or_simulate(message, 'simulating post of message: {!s}'.format(message_text))
 
 	def post_images(self, image_urls_array, pretext="", fallback="Couldn't display image"):
 		if len(image_urls_array) == 0:
@@ -43,29 +44,28 @@ class slack_bot:
 				}
 			message['attachments'].append(attachment)
 			attachment_count += 1
-		message['attachments'] = [attachment]
-		payload = {'payload':json.dumps(message)}
-		self._send_or_simulate(payload, 'simulating post of images: {!s}'.format(str(image_urls_array)))
+		message['attachments'] = json.dumps([attachment])
+		self._send_or_simulate(message, 'simulating post of images: {!s}'.format(str(image_urls_array)))
 
 	def post_multiline_message(self, message_text):
 		message = self.default_message.copy()
 		attachment = {
 		'text': message_text
 		}
-		message['attachments'] = [attachment]
-		payload = {'payload':json.dumps(message)}
-		self._send_or_simulate(payload, 'simulating post of multi-line message: {!s}'.format(message_text))
+		message['attachments'] = json.dumps([attachment])
+		self._send_or_simulate(message, 'simulating post of multi-line message: {!s}'.format(message_text))
 
 	def post_attachment(self, attachment):
 		message = self.default_message.copy()
 		attachment = attachment
-		message['attachments'] = [attachment]
-		payload = {'payload':json.dumps(message)}
-		self._send_or_simulate(payload, 'simulating post of multi-line message')
+		message['attachments'] = json.dumps([attachment])
+		self._send_or_simulate(message, 'simulating post of multi-line message')
 
 	def _send_or_simulate(self, payload, simulate_text):
 		if self.live:
-			self.session.post(self.hook_url, data=payload)
+			print(payload)
+			response = self.session.post("https://slack.com/api/chat.postMessage", params=payload)
+			print(response.json())
 		else:
 			write_to_log(simulate_text)
 
@@ -80,3 +80,4 @@ def write_to_log(message_text, log=True):
 		log_file = '{!s}/log.txt'.format(log_directory)
 		with open(log_file, 'a+') as file:
 			file.write(message_to_log)
+

--- a/app/results.settings
+++ b/app/results.settings
@@ -1,7 +1,4 @@
 	{
-		"channel_url":"https://hooks.slack.com/services/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",
-		"channel_name":"#fun-house",
-		"testing_channel_name":"#jhcmagic-testing",
 		"bot_name":"Jace, the Result Sculptor",
 		"bot_icon":"http://i.imgur.com/80oo6Aw.png"
 	}

--- a/app/slackApiChannel.py
+++ b/app/slackApiChannel.py
@@ -37,17 +37,5 @@ class Channel:
 				for item in historyResponse['messages']:
 					self.history.append(item)
 
-	def getChannelName(self):
-		payload = {
-		'token' : self.token,
-		'channel' : self.channelId
-		}
-
-		response = self.session.get('https://slack.com/api/users.info', params=payload)
-		data = response.json()
-		if response.status_code == 200 and data['ok']:
-			return data['channel']['name']
-
-
 
 

--- a/app/slackApiChannel.py
+++ b/app/slackApiChannel.py
@@ -12,48 +12,21 @@ from app import app
 
 class Channel:
 
-	def __init__(self, token, channelName):
-		self.channelName = channelName
+	def __init__(self, token, channelId):
+		self.channelId = channelId
 		self.token = token
 		self.session = requests.session()
-		self.history = []
-
-		if app.config['TESTING'] == True:
-			self.oldest = 0
-		else:
-			self.oldest = time.mktime(date.today().timetuple())
-
-		with open('app/pairings.settings') as config:
-			settings = json.loads(config.read())	
-		
 
 	def getPairingsMessage(self):
-		self.getChannelFromList()
-		
-		for item in self.history:
+		for item in self.getChannelHistoryForToday():
 			if item['type'] == 'message' and item['user'] == 'USLACKBOT' and item['text'] == 'Reminder: <!here> :pear: :ring: s?':
 				return item
-
-
-	def getChannelFromList(self):
-		payload = {'token': self.token}
-
-		response = self.session.get('https://slack.com/api/channels.list', params=payload)
-
-		if response.status_code == 200:
-			channelListResponse = response.json()
-			if channelListResponse['ok']:
-				for channel in channelListResponse['channels']:
-					if channel['name'] == self.channelName:
-						self.channelId = channel['id']
-						self.getChannelHistoryForToday()
-			
 
 	def getChannelHistoryForToday(self):
 		payload = {
 		'token' : self.token,
 		'channel' : self.channelId,
-		'oldest' : self.oldest
+		'oldest' : time.mktime(date.today().timetuple())
 		}
 
 		response = self.session.get('https://slack.com/api/channels.history', params=payload)
@@ -63,6 +36,18 @@ class Channel:
 			if historyResponse['ok']:
 				for item in historyResponse['messages']:
 					self.history.append(item)
+
+	def getChannelName(self):
+		payload = {
+		'token' : self.token,
+		'channel' : self.channelId
+		}
+
+		response = self.session.get('https://slack.com/api/users.info', params=payload)
+		data = response.json()
+		if response.status_code == 200 and data['ok']:
+			return data['channel']['name']
+
 
 
 

--- a/app/slackApiUser.py
+++ b/app/slackApiUser.py
@@ -23,7 +23,7 @@ class User:
 		'user' : self.userId
 		}
 
-		response = self.session.get('https://slack.com/api/channels.info', params=payload)
+		response = self.session.get('https://slack.com/api/users.info', params=payload)
 		if response.status_code == 200:
 			self.parseUserInfo(response.json())
 			

--- a/app/slackApiUser.py
+++ b/app/slackApiUser.py
@@ -23,7 +23,7 @@ class User:
 		'user' : self.userId
 		}
 
-		response = self.session.get('https://slack.com/api/users.info', params=payload)
+		response = self.session.get('https://slack.com/api/channels.info', params=payload)
 		if response.status_code == 200:
 			self.parseUserInfo(response.json())
 			


### PR DESCRIPTION
- replace the use of any webhooks with the slack api
- replace the storage of channel details in config json with accessing environment variables
- instead of using channel names, use channel IDs